### PR TITLE
CVE-2021-26291 issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,12 @@
         <repository>
             <id>com.springsource.repository.bundles.release</id>
             <name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-            <url>http://repository.springsource.com/maven/bundles/release</url>
+            <url>https://repository.springsource.com/maven/bundles/release</url>
         </repository>
         <repository>
             <id>com.springsource.repository.bundles.external</id>
             <name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-            <url>http://repository.springsource.com/maven/bundles/external</url>
+            <url>https://repository.springsource.com/maven/bundles/external</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
In Maven 3.8.1 it has been fixed a man in the middle security issue, so http repositories dependencies will be blocked by default.
Here is the description of the issue [CVE-2021-26291](https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291).

Specifically, I get this error:
**Could not transfer artifact net.sourceforge.tcljava:com.springsource.tcl.lang.jacl:pom:1.4.1 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [com.springsource.repository.bundles.release (http://repository.springsource.com/maven/bundles/release, default, releases+snapshots), com.springsource.repository.bundles.external (http://repository.springsource.com/maven/bundles/external, default, releases+snapshots)] -> [Help 1]**
